### PR TITLE
Lines impelementation

### DIFF
--- a/public/js/lines.js
+++ b/public/js/lines.js
@@ -25,6 +25,10 @@ $.fn.extend({
     }
 });
 
+function init_lines_mobile() {
+    
+}
+
 function init_lines() {
     // TODO: make call this on every page, instead of hardcoding it for each endpoint
     $("body").off("click");


### PR DESCRIPTION
before user could click on the full nav when a content page was on top of it (if you click in between the grids). changed the click() function, but still need to remove cursor on hover.